### PR TITLE
Don't spawn monsters in Peaceful difficulty in the Nether populator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.1.0</build.version>
+        <build.version>1.1.1</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Poseidon</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
+++ b/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Difficulty;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
@@ -34,6 +36,12 @@ public class PoseidonBlockPop extends BlockPopulator {
     private static final List<EntityType> WATER_MOBS = List.of(EntityType.DROWNED, EntityType.GUARDIAN,
             EntityType.ELDER_GUARDIAN, EntityType.GLOW_SQUID, EntityType.SQUID, EntityType.DROWNED, EntityType.DROWNED,
             EntityType.DROWNED, EntityType.GLOW_SQUID);
+    /**
+     * Monsters in {@link #WATER_MOBS} that cannot be spawned on Peaceful difficulty.
+     * Attempting to spawn these on Peaceful throws an IllegalStateException.
+     */
+    private static final Set<EntityType> MONSTERS = Set.of(EntityType.DROWNED, EntityType.GUARDIAN,
+            EntityType.ELDER_GUARDIAN);
     private static final Random RANDOM = new Random();
     private static NavigableMap<Double, TreeType> treeMap = new TreeMap<>();
 
@@ -69,6 +77,10 @@ public class PoseidonBlockPop extends BlockPopulator {
         int startX = chunkX << 4;
         int startZ = chunkZ << 4;
 
+        // Monsters cannot be spawned on Peaceful difficulty - doing so throws an exception
+        World world = Bukkit.getWorld(worldInfo.getUID());
+        boolean peaceful = world != null && world.getDifficulty() == Difficulty.PEACEFUL;
+
         // Spawn a limited number of water mobs
         for (int i = 0; i < maxMobsPerChunk; i++) {
             // Randomly select a block within the chunk
@@ -84,8 +96,13 @@ public class PoseidonBlockPop extends BlockPopulator {
                 EntityType mobType = WATER_MOBS.stream().skip(random.nextInt(WATER_MOBS.size())).findFirst()
                         .orElse(EntityType.DROWNED);
 
+                // Skip monsters on Peaceful difficulty as they cannot be spawned
+                if (peaceful && MONSTERS.contains(mobType)) {
+                    continue;
+                }
+
                 // Spawn the mob at the water block's location
-                Location spawnLocation = new Location(Bukkit.getWorld(worldInfo.getUID()), x, y, z);
+                Location spawnLocation = new Location(world, x, y, z);
                 limitedRegion.spawnEntity(spawnLocation, mobType);
             }
         }


### PR DESCRIPTION
## Problem

Running against Paper 26.2, world creation crashes when the Nether block populator tries to spawn a monster on a Peaceful world:

```
Caused by: java.lang.IllegalStateException: Cannot spawn monster for org.bukkit.entity.Drowned in Peaceful difficulty
    at world.bentobox.poseidon.generator.PoseidonBlockPop.netherPop(PoseidonBlockPop.java:89)
    at world.bentobox.poseidon.generator.PoseidonBlockPop.populate(PoseidonBlockPop.java:61)
    at world.bentobox.poseidon.Poseidon.getWorld(Poseidon.java:167)
    at world.bentobox.poseidon.Poseidon.createWor...
```

Discovered by the daily integration smoke tests: https://github.com/BentoBoxWorld/bbox-test-harness/actions/runs/28331849010/job/83931234762

## Fix

`netherPop` now checks the world difficulty and skips spawning monsters (`DROWNED`, `GUARDIAN`, `ELDER_GUARDIAN`) when the world is on Peaceful difficulty, since Bukkit refuses to spawn monsters there and throws. Squids and glow squids are unaffected and still spawn.

Version bumped to `1.1.1` (bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)