### PR TITLE
Make Peaceful spawn guard robust during world creation

### DIFF
--- a/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
+++ b/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
@@ -50,6 +50,7 @@ public class PoseidonBlockPop extends BlockPopulator {
     private int treeDensity;
     private int turtleEggs;
     private double fisherman;
+    private final Difficulty configuredDifficulty;
 
     public PoseidonBlockPop(Poseidon addon) {
         maxMobsPerChunk = addon.getSettings().getMobsPerChunk();
@@ -58,6 +59,7 @@ public class PoseidonBlockPop extends BlockPopulator {
         treeDensity = addon.getSettings().getIslandTrees();
         turtleEggs = addon.getSettings().getTurtleEggs();
         fisherman = addon.getSettings().getFisherman() / 25600D; // 16 x 16 blocks in chunk
+        configuredDifficulty = addon.getSettings().getDifficulty();
     }
 
     @Override
@@ -77,9 +79,11 @@ public class PoseidonBlockPop extends BlockPopulator {
         int startX = chunkX << 4;
         int startZ = chunkZ << 4;
 
-        // Monsters cannot be spawned on Peaceful difficulty - doing so throws an exception
+        // Monsters cannot be spawned on Peaceful difficulty - doing so throws an exception.
+        // The world may not be registered with Bukkit yet (this populator runs during world
+        // creation), so fall back to the addon's configured difficulty when it is unavailable.
         World world = Bukkit.getWorld(worldInfo.getUID());
-        boolean peaceful = world != null && world.getDifficulty() == Difficulty.PEACEFUL;
+        boolean peaceful = (world != null ? world.getDifficulty() : configuredDifficulty) == Difficulty.PEACEFUL;
 
         // Spawn a limited number of water mobs
         for (int i = 0; i < maxMobsPerChunk; i++) {
@@ -101,9 +105,15 @@ public class PoseidonBlockPop extends BlockPopulator {
                     continue;
                 }
 
-                // Spawn the mob at the water block's location
-                Location spawnLocation = new Location(world, x, y, z);
-                limitedRegion.spawnEntity(spawnLocation, mobType);
+                // Spawn the mob at the water block's location. Spawning is guarded defensively:
+                // a failure here (e.g. monsters on Peaceful) must not propagate and crash the
+                // chunk system during world generation.
+                try {
+                    Location spawnLocation = new Location(world, x, y, z);
+                    limitedRegion.spawnEntity(spawnLocation, mobType);
+                } catch (IllegalStateException e) {
+                    // Mob could not be spawned here (e.g. difficulty restriction) - skip it
+                }
             }
         }
 


### PR DESCRIPTION
Follow-up to #15. The smoke test still crashed with the exact same stack trace because the released jar pre-dates that fix — **and** because the original guard was not robust enough for this code path.

## Why #15 alone wasn't sufficient

The populator runs *while the world is still being created*, inside `WorldCreator.createWorld()` (`Poseidon.getWorld:167` → `createWorlds:140`). At that point the world is **not yet registered** with Bukkit, so `Bukkit.getWorld(worldInfo.getUID())` can return `null`, the `peaceful` flag evaluates to `false`, and monster spawns proceed — crashing the chunk system again:

```
Caused by: java.lang.IllegalStateException: Cannot spawn monster for org.bukkit.entity.Drowned in Peaceful difficulty
    at world.bentobox.poseidon.generator.PoseidonBlockPop.netherPop(PoseidonBlockPop.java:89)
Caused by: java.lang.RuntimeException: Chunk system crash propagated from unrecoverableChunkSystemFailure
```

(seen in https://github.com/BentoBoxWorld/bbox-test-harness/actions/runs/28332381857/job/83932707724)

## Fix

- **Fallback difficulty source**: when the live world isn't registered yet, fall back to the addon's configured difficulty (`Settings.getDifficulty()`).
- **Defensive spawn**: wrap `spawnEntity` in a `try/catch (IllegalStateException)`. This is the real guarantee — a failed spawn for *any* reason (difficulty restriction, detection mismatch) is caught locally and can never propagate into an unrecoverable chunk-system failure during world generation.

No further version bump needed — #15 already set the version to 1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)