### PR TITLE
Release 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.1.0</build.version>
+        <build.version>1.1.1</build.version>
         <!-- Sonar Cloud -->
         <sonar.projectKey>BentoBoxWorld_Poseidon</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
+++ b/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
@@ -50,6 +50,7 @@ public class PoseidonBlockPop extends BlockPopulator {
     private int treeDensity;
     private int turtleEggs;
     private double fisherman;
+    private final Difficulty configuredDifficulty;
 
     public PoseidonBlockPop(Poseidon addon) {
         maxMobsPerChunk = addon.getSettings().getMobsPerChunk();
@@ -58,6 +59,7 @@ public class PoseidonBlockPop extends BlockPopulator {
         treeDensity = addon.getSettings().getIslandTrees();
         turtleEggs = addon.getSettings().getTurtleEggs();
         fisherman = addon.getSettings().getFisherman() / 25600D; // 16 x 16 blocks in chunk
+        configuredDifficulty = addon.getSettings().getDifficulty();
     }
 
     @Override
@@ -77,9 +79,11 @@ public class PoseidonBlockPop extends BlockPopulator {
         int startX = chunkX << 4;
         int startZ = chunkZ << 4;
 
-        // Monsters cannot be spawned on Peaceful difficulty - doing so throws an exception
+        // Monsters cannot be spawned on Peaceful difficulty - doing so throws an exception.
+        // The world may not be registered with Bukkit yet (this populator runs during world
+        // creation), so fall back to the addon's configured difficulty when it is unavailable.
         World world = Bukkit.getWorld(worldInfo.getUID());
-        boolean peaceful = world != null && world.getDifficulty() == Difficulty.PEACEFUL;
+        boolean peaceful = (world != null ? world.getDifficulty() : configuredDifficulty) == Difficulty.PEACEFUL;
 
         // Spawn a limited number of water mobs
         for (int i = 0; i < maxMobsPerChunk; i++) {
@@ -101,9 +105,15 @@ public class PoseidonBlockPop extends BlockPopulator {
                     continue;
                 }
 
-                // Spawn the mob at the water block's location
-                Location spawnLocation = new Location(world, x, y, z);
-                limitedRegion.spawnEntity(spawnLocation, mobType);
+                // Spawn the mob at the water block's location. Spawning is guarded defensively:
+                // a failure here (e.g. monsters on Peaceful) must not propagate and crash the
+                // chunk system during world generation.
+                try {
+                    Location spawnLocation = new Location(world, x, y, z);
+                    limitedRegion.spawnEntity(spawnLocation, mobType);
+                } catch (IllegalStateException e) {
+                    // Mob could not be spawned here (e.g. difficulty restriction) - skip it
+                }
             }
         }
 

--- a/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
+++ b/src/main/java/world/bentobox/poseidon/generator/PoseidonBlockPop.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Difficulty;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
@@ -34,6 +36,12 @@ public class PoseidonBlockPop extends BlockPopulator {
     private static final List<EntityType> WATER_MOBS = List.of(EntityType.DROWNED, EntityType.GUARDIAN,
             EntityType.ELDER_GUARDIAN, EntityType.GLOW_SQUID, EntityType.SQUID, EntityType.DROWNED, EntityType.DROWNED,
             EntityType.DROWNED, EntityType.GLOW_SQUID);
+    /**
+     * Monsters in {@link #WATER_MOBS} that cannot be spawned on Peaceful difficulty.
+     * Attempting to spawn these on Peaceful throws an IllegalStateException.
+     */
+    private static final Set<EntityType> MONSTERS = Set.of(EntityType.DROWNED, EntityType.GUARDIAN,
+            EntityType.ELDER_GUARDIAN);
     private static final Random RANDOM = new Random();
     private static NavigableMap<Double, TreeType> treeMap = new TreeMap<>();
 
@@ -69,6 +77,10 @@ public class PoseidonBlockPop extends BlockPopulator {
         int startX = chunkX << 4;
         int startZ = chunkZ << 4;
 
+        // Monsters cannot be spawned on Peaceful difficulty - doing so throws an exception
+        World world = Bukkit.getWorld(worldInfo.getUID());
+        boolean peaceful = world != null && world.getDifficulty() == Difficulty.PEACEFUL;
+
         // Spawn a limited number of water mobs
         for (int i = 0; i < maxMobsPerChunk; i++) {
             // Randomly select a block within the chunk
@@ -84,8 +96,13 @@ public class PoseidonBlockPop extends BlockPopulator {
                 EntityType mobType = WATER_MOBS.stream().skip(random.nextInt(WATER_MOBS.size())).findFirst()
                         .orElse(EntityType.DROWNED);
 
+                // Skip monsters on Peaceful difficulty as they cannot be spawned
+                if (peaceful && MONSTERS.contains(mobType)) {
+                    continue;
+                }
+
                 // Spawn the mob at the water block's location
-                Location spawnLocation = new Location(Bukkit.getWorld(worldInfo.getUID()), x, y, z);
+                Location spawnLocation = new Location(world, x, y, z);
                 limitedRegion.spawnEntity(spawnLocation, mobType);
             }
         }


### PR DESCRIPTION
## Release 1.1.1

Bug-fix release.

### Fixes
- Fix server crash on world creation when running on **Peaceful** difficulty (Paper 26.2). The Nether block populator attempted to spawn monsters (Drowned / Guardian / Elder Guardian), which throws `IllegalStateException` on Peaceful and propagated into an unrecoverable chunk-system failure. (#15)
- Make the Peaceful spawn guard robust during world creation: the populator runs before the world is registered with Bukkit, so difficulty is now read from a configured fallback and the spawn is wrapped defensively so a failed spawn can never crash generation. (#16)

Discovered by the daily integration smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)